### PR TITLE
Feat: New toolbox entry + icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "hugur",
       "version": "0.1.0",
       "dependencies": {
+        "@mdi/js": "^7.2.96",
+        "@mdi/react": "^1.6.1",
         "@supabase/auth-helpers-nextjs": "^0.7.2",
         "@supabase/auth-ui-react": "^0.4.2",
         "@supabase/auth-ui-shared": "^0.1.6",
@@ -207,6 +209,19 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
+    },
+    "node_modules/@mdi/js": {
+      "version": "7.2.96",
+      "resolved": "https://registry.npmjs.org/@mdi/js/-/js-7.2.96.tgz",
+      "integrity": "sha512-paR9M9ZT7rKbh2boksNUynuSZMHhqRYnEZOm/KrZTjQ4/FzyhjLHuvw/8XYzP+E7fS4+/Ms/82EN1pl/OFsiIA=="
+    },
+    "node_modules/@mdi/react": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@mdi/react/-/react-1.6.1.tgz",
+      "integrity": "sha512-4qZeDcluDFGFTWkHs86VOlHkm6gnKaMql13/gpIcUQ8kzxHgpj31NuCkD8abECVfbULJ3shc7Yt4HJ6Wu6SN4w==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      }
     },
     "node_modules/@next/env": {
       "version": "13.4.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1926,9 +1926,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -1965,9 +1965,9 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -2044,9 +2044,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@mdi/js": "^7.2.96",
+    "@mdi/react": "^1.6.1",
     "@supabase/auth-helpers-nextjs": "^0.7.2",
     "@supabase/auth-ui-react": "^0.4.2",
     "@supabase/auth-ui-shared": "^0.1.6",

--- a/src/app/courses/[id]/toolbox/page.tsx
+++ b/src/app/courses/[id]/toolbox/page.tsx
@@ -1,15 +1,17 @@
 import { EntryFrame } from "@/components/entryFrame";
+import { NewEntry } from "@/components/newEntry";
 import { Tool } from "@/components/tool";
 
 export default function CourseToolbox() {
     let day = new Date(); // Placeholder
+
     // TODO: fetch descriptions + dates + titles from database
     return (
         <div className="w-full flex flex-col items-center">
-            <h1 className="text-4xl text-lm-medium-dark py-8">Toolbox</h1>
-            <p className="text-lm-medium-dark pb-8 w-1/2">At the end of each module, you can write down something helpful you&apos;ve learned. This is where those “tools” will appear.
+            <h1 className="text-4xl text-base-content opacity-60 py-8">Toolbox</h1>
+            <p className="text-base-content opacity-60 pb-8 w-1/2">At the end of each module, you can write down something helpful you&apos;ve learned. This is where those “tools” will appear.
 You can also add new tools at any time.</p>
-            <div className="w-2/3 flex flex-col">
+            <div className="w-2/3 flex flex-col pb-8">
                 <Tool 
                 title="Don't be sad" 
                 description="Just don't do it. Why would you be sad? Idiot" 
@@ -22,6 +24,10 @@ You can also add new tools at any time.</p>
                 title="Don't be sad" 
                 description="Just don't do it. Why would you be sad? Idiot" 
                 date={day.toLocaleDateString()} />
+                <button className="btn btn-primary flex self-center m-4">New tool</button>
+                <NewEntry title="title">
+                    bla
+                </NewEntry>
             </div>
         </div>
     )

--- a/src/app/courses/[id]/toolbox/page.tsx
+++ b/src/app/courses/[id]/toolbox/page.tsx
@@ -1,34 +1,20 @@
-import { EntryFrame } from "@/components/entryFrame";
 import { NewEntry } from "@/components/newEntry";
 import { Tool } from "@/components/tool";
+import { ToolsList } from "@/components/toolsList";
+import { useState } from "react"
 
 export default function CourseToolbox() {
-    let day = new Date(); // Placeholder
 
-    // TODO: fetch descriptions + dates + titles from database
+    // TODO: fetch tools from database
     return (
         <div className="w-full flex flex-col items-center">
             <h1 className="text-4xl text-base-content opacity-60 py-8">Toolbox</h1>
-            <p className="text-base-content opacity-60 pb-8 w-1/2">At the end of each module, you can write down something helpful you&apos;ve learned. This is where those “tools” will appear.
-You can also add new tools at any time.</p>
-            <div className="w-2/3 flex flex-col pb-8">
-                <Tool 
-                title="Don't be sad" 
-                description="Just don't do it. Why would you be sad? Idiot" 
-                date={day.toLocaleDateString()} />
-                <Tool 
-                title="Don't be sad" 
-                description="Just don't do it. Why would you be sad? Idiot" 
-                date={day.toLocaleDateString()} />
-                <Tool 
-                title="Don't be sad" 
-                description="Just don't do it. Why would you be sad? Idiot" 
-                date={day.toLocaleDateString()} />
-                <button className="btn btn-primary flex self-center m-4">New tool</button>
-                <NewEntry title="title">
-                    bla
-                </NewEntry>
-            </div>
+            <p className="text-base-content opacity-60 pb-8 w-1/2">
+                At the end of each module, you can write down something helpful you&apos;ve learned. 
+                This is where those “tools” will appear.
+                You can also add new tools at any time.
+            </p>
+            <ToolsList tools={[<Tool key={0} title="Don't be sad" description="Just don't do it. It's that easy!" date={"26/7/2023"} />]} />
         </div>
     )
 }

--- a/src/components/iconButton.tsx
+++ b/src/components/iconButton.tsx
@@ -1,0 +1,9 @@
+import Icon from "@mdi/react";
+
+export function IconButton({onClick, iconPath, btnSize="md"}) {
+    return (
+        <button onClick={onClick} className={"btn btn-primary btn-circle btn-outline border-2 btn-" + btnSize}>
+                    <Icon path={iconPath} className="w-3/4 h-3/4" />
+        </button>
+    )
+}

--- a/src/components/iconButton.tsx
+++ b/src/components/iconButton.tsx
@@ -1,9 +1,10 @@
 import Icon from "@mdi/react";
 
 export function IconButton({onClick, iconPath, btnSize="md"}) {
+    const style = "btn btn-primary btn-circle btn-outline border-2 btn-" + btnSize;
     return (
-        <button onClick={onClick} className={"btn btn-primary btn-circle btn-outline border-2 btn-" + btnSize}>
-                    <Icon path={iconPath} className="w-3/4 h-3/4" />
+        <button onClick={onClick} className={style}>
+            <Icon path={iconPath} className="w-3/4 h-3/4" />
         </button>
     )
 }

--- a/src/components/newEntry.tsx
+++ b/src/components/newEntry.tsx
@@ -12,33 +12,42 @@ export enum newEntryVariants {
 
 export interface newEntryProps {
     title: string,
-    children: ReactNode,
+    stages: Array<ReactNode>,
     onClose: React.MouseEventHandler,
-    variant?: newEntryVariants
+    onFinish: React.MouseEventHandler
 }
 
-export function NewEntry({title, children, onClose, variant=newEntryVariants.Middle}: newEntryProps) {
+export function NewEntry({title, stages, onClose, onFinish}: newEntryProps) {
+
+    const [currentStage, setCurrentStage] = useState(0);
+    const stageText = (currentStage + 1) + '/' + stages.length;
+
+    let variant = newEntryVariants.Middle;
+    if (stages.length == 1) variant = newEntryVariants.Single;
+    else if (currentStage == 0) variant = newEntryVariants.Start;
+    else if (currentStage > 0 && currentStage < (stages.length - 1)) variant = newEntryVariants.Middle;
+    else if (currentStage == (stages.length - 1)) variant = newEntryVariants.End;
 
     const navButtons = () => {
         switch (variant) {
             case newEntryVariants.Start:
                 return (
                     <div>
-                        <IconButton onClick={() => {}} iconPath={mdiArrowRight} />
+                        <IconButton onClick={() => {setCurrentStage(currentStage + 1)}} iconPath={mdiArrowRight} />
                     </div>
                 )
             case newEntryVariants.Middle:
                 return (
-                    <div>
-                        <IconButton onClick={() => {}} iconPath={mdiArrowLeft} />
-                        <IconButton onClick={() => {}} iconPath={mdiArrowRight} />
+                    <div className="flex gap-16">
+                        <IconButton onClick={() => {setCurrentStage(currentStage - 1)}} iconPath={mdiArrowLeft} />
+                        <IconButton onClick={() => {setCurrentStage(currentStage + 1)}} iconPath={mdiArrowRight} />
                     </div>
                 )
             case newEntryVariants.End:
                 return (
-                    <div>
-                        <IconButton onClick={() => {}} iconPath={mdiArrowLeft} />
-                        <IconButton onClick={() => {}} iconPath={mdiCheck} />
+                    <div className="flex gap-16">
+                        <IconButton onClick={() => {setCurrentStage(currentStage - 1)}} iconPath={mdiArrowLeft} />
+                        <IconButton onClick={onFinish} iconPath={mdiCheck} />
                     </div>
                 )
             case newEntryVariants.Single:
@@ -55,14 +64,15 @@ export function NewEntry({title, children, onClose, variant=newEntryVariants.Mid
         <div className="border border-base-content rounded-md p-4 m-8">
             <div className="relative w-full">
                 {/* Close/cancel button */}
-                <div className="absolute top-0 right-0 w-8 h-8">
+                <div className="absolute top-0 right-0">
                     <IconButton onClick={onClose} iconPath={mdiClose} btnSize="sm" />
                 </div>
                 <h1 className="font-thin tracking-widest text-2xl text-center">{title}</h1>
             </div>
-            <div className="m-4 text-center">{children}</div>
-            <div className="flex justify-center w-full">
+            <div className="m-4 text-center">{stages[currentStage]}</div>
+            <div className="flex flex-col items-center w-full">
                 {navButtons()}
+                <p className="text-base-content opacity-50 mt-4 mb-2">{stageText}</p>
             </div>
         </div>
     )

--- a/src/components/newEntry.tsx
+++ b/src/components/newEntry.tsx
@@ -1,0 +1,24 @@
+import { ReactNode, useState } from "react";
+
+export interface newEntryProps {
+    title: string,
+    children: ReactNode,
+    next?: ReactNode,
+    prev?: ReactNode
+}
+
+export function NewEntry({title, children, next, prev}: newEntryProps) {
+    return (
+        <div className="border border-base-content rounded-md p-4 m-6">
+            <div className="relative w-full">
+                <button className="btn btn-primary btn-circle btn-outline btn-sm border-2 absolute top-0 right-0">
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+                <h1 className="font-thin tracking-widest text-2xl text-center">{title}</h1>
+            </div>
+            <div className="m-4">{children}</div>
+        </div>
+    )
+}

--- a/src/components/newEntry.tsx
+++ b/src/components/newEntry.tsx
@@ -3,16 +3,15 @@ import { ReactNode, useState } from "react";
 export interface newEntryProps {
     title: string,
     children: ReactNode,
-    next?: ReactNode,
-    prev?: ReactNode
+    onClose: React.MouseEventHandler
 }
 
-export function NewEntry({title, children, next, prev}: newEntryProps) {
+export function NewEntry({title, children, onClose}: newEntryProps) {
     return (
         <div className="border border-base-content rounded-md p-4 m-8">
             <div className="relative w-full">
                 {/* Close/cancel button */}
-                <button className="btn btn-primary btn-circle btn-outline btn-sm border-2 absolute top-0 right-0">
+                <button onClick={onClose} className="btn btn-primary btn-circle btn-outline btn-sm border-2 absolute top-0 right-0">
                     <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
                     </svg>

--- a/src/components/newEntry.tsx
+++ b/src/components/newEntry.tsx
@@ -9,8 +9,9 @@ export interface newEntryProps {
 
 export function NewEntry({title, children, next, prev}: newEntryProps) {
     return (
-        <div className="border border-base-content rounded-md p-4 m-6">
+        <div className="border border-base-content rounded-md p-4 m-8">
             <div className="relative w-full">
+                {/* Close/cancel button */}
                 <button className="btn btn-primary btn-circle btn-outline btn-sm border-2 absolute top-0 right-0">
                     <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
@@ -18,7 +19,7 @@ export function NewEntry({title, children, next, prev}: newEntryProps) {
                 </button>
                 <h1 className="font-thin tracking-widest text-2xl text-center">{title}</h1>
             </div>
-            <div className="m-4">{children}</div>
+            <div className="m-4 text-center">{children}</div>
         </div>
     )
 }

--- a/src/components/newEntry.tsx
+++ b/src/components/newEntry.tsx
@@ -1,24 +1,69 @@
+import { mdiClose, mdiArrowRight, mdiArrowLeft, mdiCheck } from "@mdi/js";
+import Icon from "@mdi/react";
 import { ReactNode, useState } from "react";
+import { IconButton } from "./iconButton";
+
+export enum newEntryVariants {
+    Start,
+    Middle,
+    End,
+    Single
+}
 
 export interface newEntryProps {
     title: string,
     children: ReactNode,
-    onClose: React.MouseEventHandler
+    onClose: React.MouseEventHandler,
+    variant?: newEntryVariants
 }
 
-export function NewEntry({title, children, onClose}: newEntryProps) {
+export function NewEntry({title, children, onClose, variant=newEntryVariants.Middle}: newEntryProps) {
+
+    const navButtons = () => {
+        switch (variant) {
+            case newEntryVariants.Start:
+                return (
+                    <div>
+                        <IconButton onClick={() => {}} iconPath={mdiArrowRight} />
+                    </div>
+                )
+            case newEntryVariants.Middle:
+                return (
+                    <div>
+                        <IconButton onClick={() => {}} iconPath={mdiArrowLeft} />
+                        <IconButton onClick={() => {}} iconPath={mdiArrowRight} />
+                    </div>
+                )
+            case newEntryVariants.End:
+                return (
+                    <div>
+                        <IconButton onClick={() => {}} iconPath={mdiArrowLeft} />
+                        <IconButton onClick={() => {}} iconPath={mdiCheck} />
+                    </div>
+                )
+            case newEntryVariants.Single:
+            default:
+                return (
+                    <div>
+                        <IconButton onClick={() => {}} iconPath={mdiCheck} />
+                    </div>
+                )
+        }
+    }
+
     return (
         <div className="border border-base-content rounded-md p-4 m-8">
             <div className="relative w-full">
                 {/* Close/cancel button */}
-                <button onClick={onClose} className="btn btn-primary btn-circle btn-outline btn-sm border-2 absolute top-0 right-0">
-                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                </button>
+                <div className="absolute top-0 right-0 w-8 h-8">
+                    <IconButton onClick={onClose} iconPath={mdiClose} btnSize="sm" />
+                </div>
                 <h1 className="font-thin tracking-widest text-2xl text-center">{title}</h1>
             </div>
             <div className="m-4 text-center">{children}</div>
+            <div className="flex justify-center w-full">
+                {navButtons()}
+            </div>
         </div>
     )
 }

--- a/src/components/tool.tsx
+++ b/src/components/tool.tsx
@@ -4,7 +4,13 @@ import { EntryFrame } from "./entryFrame";
 import Image from "next/image";
 import { useState } from "react";
 
-export function Tool({title, description, date}) {
+export interface toolProps {
+    title: string,
+    description: string,
+    date: string
+}
+
+export function Tool({title, description, date}: toolProps) {
     const [isOpen, setIsOpen] = useState(false);
 
     function toggleOpen() {

--- a/src/components/toolsList.tsx
+++ b/src/components/toolsList.tsx
@@ -23,18 +23,25 @@ export function ToolsList({tools=[]}: {tools: Array<ReactNode>}) {
     return (
         <div className="w-2/3 flex flex-col pb-8">
                 {toolsList}
-                <button 
-                    onClick={addToolClicked} 
-                    className={"btn btn-primary flex self-center m-4 " + (addingEntry ? "hidden" : "visible")}
-                >
-                    New tool
-                </button>
-                <div className={addingEntry ? "visible" : "hidden"}>
-                    <NewEntry title="New Toolbox Entry" onClose={handleClose}>
-                        <p className="m-10">Pick a title for your entry</p>
-                        <input className="input input-bordered mb-6"></input>
-                    </NewEntry>
-                </div>
+                {
+                    /* New tool button: only shown if addingEntry is false */
+                    !addingEntry && 
+                        <button 
+                            onClick={addToolClicked} 
+                            className="btn btn-primary flex self-center m-4 "
+                        >
+                            New tool
+                        </button>
+                }
+                
+                {
+                    /* New tool form: only shown if addingEntry is true */
+                    addingEntry && 
+                        <NewEntry title="New Toolbox Entry" onClose={handleClose}>
+                            <p className="m-10">Pick a title for your entry</p>
+                            <input className="input input-bordered mb-6"></input>
+                        </NewEntry>
+                }
             </div>
     )
 }

--- a/src/components/toolsList.tsx
+++ b/src/components/toolsList.tsx
@@ -31,7 +31,8 @@ export function ToolsList({tools=[]}: {tools: Array<ReactNode>}) {
                 </button>
                 <div className={addingEntry ? "visible" : "hidden"}>
                     <NewEntry title="New Toolbox Entry" onClose={handleClose}>
-                        Pick a title for your entry
+                        <p className="m-10">Pick a title for your entry</p>
+                        <input className="input input-bordered mb-6"></input>
                     </NewEntry>
                 </div>
             </div>

--- a/src/components/toolsList.tsx
+++ b/src/components/toolsList.tsx
@@ -20,6 +20,22 @@ export function ToolsList({tools=[]}: {tools: Array<ReactNode>}) {
         setAddingEntry(false);
     }
 
+    function addNewEntry() {
+        // TODO: Add new entry from input
+        setAddingEntry(false);
+    }
+
+    const newEntryStages = [
+        (<div key="0">
+            <p className="m-10">Pick a title for your entry</p>
+            <input className="input input-bordered mb-6" />
+        </div>),
+        (<div key="1">
+            <p className="m-10">What would you like to note down for the future?</p>
+            <textarea className="textarea textarea-bordered" />
+        </div>)
+    ]
+
     return (
         <div className="w-2/3 flex flex-col pb-8">
                 {toolsList}
@@ -37,10 +53,7 @@ export function ToolsList({tools=[]}: {tools: Array<ReactNode>}) {
                 {
                     /* New tool form: only shown if addingEntry is true */
                     addingEntry && 
-                        <NewEntry title="New Toolbox Entry" onClose={handleClose}>
-                            <p className="m-10">Pick a title for your entry</p>
-                            <input className="input input-bordered mb-6"></input>
-                        </NewEntry>
+                        <NewEntry title="New Toolbox Entry" stages={newEntryStages} onClose={handleClose} onFinish={addNewEntry} />
                 }
             </div>
     )

--- a/src/components/toolsList.tsx
+++ b/src/components/toolsList.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { ReactNode, useState } from "react"
+import { Tool } from "./tool"
+import { NewEntry } from "./newEntry";
+
+export function ToolsList({tools=[]}: {tools: Array<ReactNode>}) {
+
+    let day = new Date(); // Placeholder
+
+    const [toolsList, setToolsList] = useState(tools);
+    const [addingEntry, setAddingEntry] = useState(true);
+
+    function addToolClicked() {
+        // setToolsList([toolsList.concat(<Tool title="Don't be sad" description="Just don't do it. It's that easy!" date={day.toLocaleDateString()} />)])
+        setAddingEntry(true);
+    }
+
+    function handleClose() {
+        setAddingEntry(false);
+    }
+
+    return (
+        <div className="w-2/3 flex flex-col pb-8">
+                {toolsList}
+                <button 
+                    onClick={addToolClicked} 
+                    className={"btn btn-primary flex self-center m-4 " + (addingEntry ? "hidden" : "visible")}
+                >
+                    New tool
+                </button>
+                <div className={addingEntry ? "visible" : "hidden"}>
+                    <NewEntry title="New Toolbox Entry" onClose={handleClose}>
+                        Pick a title for your entry
+                    </NewEntry>
+                </div>
+            </div>
+    )
+}


### PR DESCRIPTION
- Added NewEntry component that goes down a list of 'stages' to get input from user
- Added Material Design Icons package to project
- Refactored tools on toolbox page into a ToolsList component, so the whole page doesn't have to be client-side
- NOTE: NewEntry doesn't actually do anything with the input yet